### PR TITLE
Enable Vitess v5.0.1 on Production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: Vitess
   sub_title: Storage
   project_url: "https://github.com/vitessio/vitess"
-  stable_ref: "v5.0.0"
+  stable_ref: "v6.0.0"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: Vitess
   sub_title: Storage
   project_url: "https://github.com/vitessio/vitess"
-  stable_ref: "v6.0.0"
+  stable_ref: "v5.0.1"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: Vitess
   sub_title: Storage
   project_url: "https://github.com/vitessio/vitess"
-  stable_ref: "v4.0.1"
+  stable_ref: "v5.0.0"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
## Description
  - v5.0.1 is latest release
  - update stable on production

## Issues:

 https://github.com/vulk/cncf_ci/issues/343

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [ ]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [ ]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
